### PR TITLE
Prevent passing null value to explode()

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -130,13 +130,17 @@ class Data extends AbstractData
     /**
      * @param null $scopeId
      *
-     * @return mixed
+     * @return array
      */
-    public function getWhitelistIpsConfig($scopeId = null)
+    public function getWhitelistIpsConfig($scopeId = null) : array
     {
         $whitelistIp = $this->getConfigGeneral(self::XML_PATH_WHITELIST_IP, $scopeId);
 
-        return explode(',', $whitelistIp);
+        if ($whitelistIp !== null) {
+            return explode(',', $whitelistIp);
+        }
+
+        return [];
     }
 
     /**


### PR DESCRIPTION
Hey,

This fixes an error which occurs when using the module with PHP 8:

```
main.ERROR: Deprecated Functionality: explode(): Passing null to parameter #2 ($string) of type string is deprecated in mageplaza/module-two-factor-authentication/Helper/Data.php on line 139 [] []
main.CRITICAL: Exception: Deprecated Functionality: explode(): Passing null to parameter #2 ($string) of type string is deprecated in mageplaza/module-two-factor-authentication/Helper/Data.php on line 139 in vendor/magento/framework/App/ErrorHandler.php:61
```

Related issue #19 